### PR TITLE
Throw error if string_length > maxlen in pad_sequences

### DIFF
--- a/src/sentiment.jl
+++ b/src/sentiment.jl
@@ -8,6 +8,8 @@ function pad_sequences(l, maxlen=500)
             push!(res, ele)
         end
         return res
+    else
+        throw("String length exceeds maximum length.")
     end
 end
 


### PR DESCRIPTION
Fixes: https://github.com/JuliaText/TextAnalysis.jl/issues/183

I haven't added the test as `pad_sequenses` is not being exported. How should go about adding it?